### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    branches: [ "main", "release/*" ]
+    branches: [ "main", "dev" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "bitflags",
  "postcard",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +19,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "beat"
@@ -30,10 +45,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "cobs"
@@ -46,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "beat",
  "cue",
@@ -55,6 +105,12 @@ dependencies = [
  "mem",
  "protocol",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "critical-section"
@@ -98,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,10 +183,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "local"
@@ -132,6 +234,7 @@ version = "0.0.0"
 dependencies = [
  "beat",
  "bitflags",
+ "chrono",
  "cue",
  "event",
  "mem",
@@ -150,6 +253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "mem"
 version = "0.0.0"
 dependencies = [
@@ -163,6 +272,21 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "postcard"
@@ -218,6 +342,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -281,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,3 +473,107 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]

--- a/beat/src/beat.rs
+++ b/beat/src/beat.rs
@@ -1,8 +1,6 @@
-use core::fmt;
-
 /// Beat represent a musical beat, or a subdivision thereof
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Default, PartialEq, Copy)]
+#[derive(Clone, Default, PartialEq, Copy, Debug)]
 pub struct Beat {
     /// Beat number, first beat in a bar typically has 1, followed by 2 etc. Can be between 0 and 255.
     pub count: u8,
@@ -14,15 +12,6 @@ pub struct Beat {
     /// In practice, the top speed of beat processing is limited by core performance, and a beat
     /// processing speed of 1MHz is probably unlikely.
     pub length: u32,
-}
-
-impl fmt::Debug for Beat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Beat")
-            .field("count", &self.count)
-            .field("length", &self.length)
-            .finish()
-    }
 }
 
 impl Beat {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2024"
 
 [dependencies]

--- a/cue/src/showmetadata.rs
+++ b/cue/src/showmetadata.rs
@@ -1,6 +1,6 @@
 use mem::str::StaticString;
 
-/// Metadata for a Show instance. Like with [crate::cue::CueMetadata], anything that is human readable and
+/// Metadata for a Show instance. Like with [crate::cuemetadata::CueMetadata], anything that is human readable and
 /// might be of interest to anyone without in-depth technical knowledge about the inner workings
 /// of ClicKS should be in ShowMetadata in a human readable format.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/local/Cargo.toml
+++ b/local/Cargo.toml
@@ -11,9 +11,10 @@ bitflags = { version = "2.10.0" }
 serde = { version = "1.0.228", features = ["serde_derive", "derive"], default-features = false, optional = true }
 serde_json = { version = "1.0.145", optional = true, default-features = false, features = ["alloc"]  }
 postcard = { version = "1.1.3", optional = true }
+chrono = { version = "0.4.42", optional = true }
 
 [features]
 serde = ["dep:serde"]
-std = []
+std = ["dep:chrono"]
 postcard = ["dep:postcard"]
 json = ["dep:serde_json"]

--- a/local/src/audiosource.rs
+++ b/local/src/audiosource.rs
@@ -1,5 +1,4 @@
-use crate::{beatstate::BeatState, playbackstate::PlaybackState};
-use mem::smpte::TimecodeInstant;
+use crate::{beatstate::BeatState, playbackstate::PlaybackState, status::TimecodeState};
 
 /// Wrapper type for the state of an audio source (audio channel)
 #[derive(Clone, Debug, Copy)]
@@ -7,7 +6,7 @@ pub enum AudioSourceState {
     /// Metronome channel state
     BeatStatus(BeatState),
     /// Timecode channel state
-    TimeStatus(TimecodeInstant),
+    TimeStatus(TimecodeState),
     /// Playback channel state
     PlaybackStatus(PlaybackState),
 }

--- a/local/src/beatstate.rs
+++ b/local/src/beatstate.rs
@@ -14,4 +14,6 @@ pub struct BeatState {
     /// Requested change of VLT. An audio source can't change the VLT by itself, so it must be
     /// forwarded to a module that can.
     pub requested_vlt_action: JumpModeChange,
+    /// Microseconds left until next beat occurs
+    pub us_to_next_beat: u32,
 }

--- a/local/src/combinedstatus.rs
+++ b/local/src/combinedstatus.rs
@@ -4,7 +4,6 @@ use crate::{
     status::TimecodeState, transportstate::TransportState,
 };
 use cue::Show;
-use mem::smpte::TimecodeInstant;
 
 /// Wrapper type for the core audio processing status.
 #[derive(Clone, Debug)]
@@ -21,8 +20,6 @@ pub struct CombinedStatus {
     pub network_status: NetworkStatus,
     /// JACK audio server-client status
     pub jack_status: JACKStatus,
-    /// SMPTE LTC status
-    pub ltc: TimecodeState,
 }
 
 impl Default for CombinedStatus {
@@ -30,7 +27,7 @@ impl Default for CombinedStatus {
         Self {
             sources: [
                 AudioSourceState::BeatStatus(BeatState::default()),
-                AudioSourceState::TimeStatus(TimecodeInstant::default()),
+                AudioSourceState::TimeStatus(TimecodeState::default()),
                 AudioSourceState::PlaybackStatus(PlaybackState::default()),
                 AudioSourceState::PlaybackStatus(PlaybackState::default()),
                 AudioSourceState::PlaybackStatus(PlaybackState::default()),
@@ -67,7 +64,6 @@ impl Default for CombinedStatus {
             show: Show::default(),
             network_status: NetworkStatus::default(),
             jack_status: JACKStatus::default(),
-            ltc: TimecodeState::default(),
         }
     }
 }
@@ -88,9 +84,9 @@ impl CombinedStatus {
         }
     }
     /// Get the timecode time state from channel 2
-    pub fn time_state(&self) -> TimecodeInstant {
+    pub fn time_state(&self) -> TimecodeState {
         if self.sources.is_empty() {
-            return TimecodeInstant::default();
+            return TimecodeState::default();
         }
         if let AudioSourceState::TimeStatus(state) = &self.sources[1] {
             *state

--- a/local/src/combinedstatus.rs
+++ b/local/src/combinedstatus.rs
@@ -1,7 +1,7 @@
 use crate::{
     audiosource::AudioSourceState, beatstate::BeatState, cuestate::CueState,
     jackstatus::JACKStatus, networkstatus::NetworkStatus, playbackstate::PlaybackState,
-    transportstate::TransportState,
+    status::TimecodeState, transportstate::TransportState,
 };
 use cue::Show;
 use mem::smpte::TimecodeInstant;
@@ -21,6 +21,8 @@ pub struct CombinedStatus {
     pub network_status: NetworkStatus,
     /// JACK audio server-client status
     pub jack_status: JACKStatus,
+    /// SMPTE LTC status
+    pub ltc: TimecodeState,
 }
 
 impl Default for CombinedStatus {
@@ -65,6 +67,7 @@ impl Default for CombinedStatus {
             show: Show::default(),
             network_status: NetworkStatus::default(),
             jack_status: JACKStatus::default(),
+            ltc: TimecodeState::default(),
         }
     }
 }

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -15,6 +15,7 @@ mod loggingconfig;
 #[cfg(feature = "std")]
 mod networkstatus;
 mod playbackstate;
+mod smallcuestate;
 mod systemconfig;
 mod transportstate;
 
@@ -49,5 +50,6 @@ pub mod status {
     #[cfg(feature = "std")]
     pub use super::networkstatus::NetworkStatus;
     pub use super::playbackstate::PlaybackState;
+    pub use super::smallcuestate::SmallCueState;
     pub use super::transportstate::TransportState;
 }

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -13,10 +13,13 @@ mod cuestate;
 mod jackstatus;
 mod loggingconfig;
 #[cfg(feature = "std")]
+mod logitem;
+#[cfg(feature = "std")]
 mod networkstatus;
 mod playbackstate;
 mod smallcuestate;
 mod systemconfig;
+mod timecodestate;
 mod transportstate;
 
 pub mod config {
@@ -31,6 +34,8 @@ pub mod config {
     pub use super::loggingconfig::LogContext;
     pub use super::loggingconfig::LogKind;
     pub use super::loggingconfig::LoggerConfiguration;
+    #[cfg(feature = "std")]
+    pub use super::logitem::LogItem;
     pub use super::systemconfig::SystemConfiguration;
     pub use super::systemconfig::SystemConfigurationChange;
 }
@@ -51,5 +56,6 @@ pub mod status {
     pub use super::networkstatus::NetworkStatus;
     pub use super::playbackstate::PlaybackState;
     pub use super::smallcuestate::SmallCueState;
+    pub use super::timecodestate::TimecodeState;
     pub use super::transportstate::TransportState;
 }

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -14,6 +14,7 @@ mod jackstatus;
 mod loggingconfig;
 #[cfg(feature = "std")]
 mod logitem;
+mod metronomeconfig;
 #[cfg(feature = "std")]
 mod networkstatus;
 mod playbackstate;
@@ -36,6 +37,10 @@ pub mod config {
     pub use super::loggingconfig::LoggerConfiguration;
     #[cfg(feature = "std")]
     pub use super::logitem::LogItem;
+    pub use super::metronomeconfig::MetronomeClick;
+    pub use super::metronomeconfig::MetronomeConfiguration;
+    pub use super::metronomeconfig::MetronomeWaveform;
+
     pub use super::systemconfig::SystemConfiguration;
     pub use super::systemconfig::SystemConfigurationChange;
 }

--- a/local/src/logitem.rs
+++ b/local/src/logitem.rs
@@ -1,0 +1,29 @@
+use crate::config::{LogContext, LogKind};
+
+extern crate std;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Clone, Debug)]
+/// A debug (or information, warning, error) log entry
+pub struct LogItem {
+    /// Logged string; to print out, display or save, in its entirety.
+    pub message: std::string::String,
+    /// Category of this log entry
+    pub kind: LogKind,
+    /// Context for this log entry; which component it came from
+    pub context: LogContext,
+    /// UTC millisecond timestamp of this log entry
+    pub time: u64,
+}
+
+impl LogItem {
+    /// Construct a new log entry with automatic timestamp
+    pub fn new(msg: std::string::String, context: LogContext, kind: LogKind) -> Self {
+        Self {
+            message: msg,
+            kind,
+            context,
+            time: chrono::Utc::now().timestamp_millis() as u64,
+        }
+    }
+}

--- a/local/src/metronomeconfig.rs
+++ b/local/src/metronomeconfig.rs
@@ -1,0 +1,94 @@
+#[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum MetronomeWaveform {
+    Sine,
+    SquircleSine,
+    Square,
+    Triangle,
+}
+
+/// Defines the parameters for a single metronome "blip"
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub struct MetronomeClick {
+    /// Frequency in Hz
+    pub frequency: u16,
+    /// Length in ms
+    pub length: u16,
+    /// Waveform
+    pub wave: MetronomeWaveform,
+}
+
+/// Configuration for metronome settings; 4 different levels of click settings
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub struct MetronomeConfiguration {
+    /// Primary click; generally beat 1
+    pub click_primary: MetronomeClick,
+    /// Secondary click: generally beat 2, 3, 4 etc.
+    pub click_secondary: MetronomeClick,
+    /// Tertiary click: generally offbeats
+    pub click_tertiary: MetronomeClick,
+    /// Quartenary click: generally 16ths or triplets
+    pub click_quartenary: MetronomeClick,
+}
+
+impl Default for MetronomeConfiguration {
+    fn default() -> Self {
+        Self {
+            click_primary: MetronomeClick {
+                frequency: 800,
+                length: 4,
+                wave: MetronomeWaveform::SquircleSine,
+            },
+            click_secondary: MetronomeClick {
+                frequency: 400,
+                length: 4,
+                wave: MetronomeWaveform::SquircleSine,
+            },
+            click_tertiary: MetronomeClick {
+                frequency: 200,
+                length: 4,
+                wave: MetronomeWaveform::SquircleSine,
+            },
+            click_quartenary: MetronomeClick {
+                frequency: 1600,
+                length: 4,
+                wave: MetronomeWaveform::SquircleSine,
+            },
+        }
+    }
+}
+
+impl MetronomeClick {
+    /// Generate a wave buffer for this click
+    #[cfg(feature = "std")]
+    pub fn buffer(&self, sample_rate: u32) -> [f32; 96000] {
+        let mut buf = [0f32; 96000];
+        let func = match self.wave {
+            MetronomeWaveform::Sine => |f: f32| f32::sin(f),
+            MetronomeWaveform::SquircleSine => |f: f32| {
+                let fs = f32::sin(f);
+                fs / (fs.abs() + 0.5).abs() * 1.5
+            },
+            MetronomeWaveform::Square => |f: f32| {
+                let fs = f32::sin(f);
+                fs.signum()
+            },
+            MetronomeWaveform::Triangle => |f: f32| {
+                let mut out = f / 2.0 * core::f32::consts::PI - 1.0;
+                out %= 1.0;
+                out -= 0.5;
+                out = out.abs();
+                4.0 * out - 1.0
+            },
+        };
+        for i in 0..self.length as u32 * sample_rate / 1000 {
+            buf[i as usize] = (func)(
+                i as f32 * core::f32::consts::PI * self.frequency as f32 * 2.0 / sample_rate as f32,
+            ) * 0.1_f32;
+        }
+        buf
+    }
+}

--- a/local/src/smallcuestate.rs
+++ b/local/src/smallcuestate.rs
@@ -1,0 +1,11 @@
+use cue::CueMetadata;
+
+/// Status of the current cue in a lightweight, const-size format
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, Copy)]
+pub struct SmallCueState {
+    /// Cue idx of this cue in the show
+    pub cue_idx: u16,
+    /// Cue data itself
+    pub cue_metadata: CueMetadata,
+}

--- a/local/src/systemconfig.rs
+++ b/local/src/systemconfig.rs
@@ -1,5 +1,7 @@
 use crate::{
-    audioconfig::AudioConfiguration, channelconfig::ChannelConfiguration,
+    audioconfig::AudioConfiguration,
+    channelconfig::ChannelConfiguration,
+    config::{MetronomeClick, MetronomeConfiguration, MetronomeWaveform},
     loggingconfig::LoggerConfiguration,
 };
 use mem::str::StaticString;
@@ -14,6 +16,8 @@ pub struct SystemConfiguration {
     pub logger: LoggerConfiguration,
     /// Audio channel configuration values
     pub channels: [ChannelConfiguration; 32],
+    /// Metronome settings
+    pub metronome: MetronomeConfiguration,
 }
 
 impl SystemConfiguration {
@@ -24,6 +28,9 @@ impl SystemConfiguration {
             SystemConfigurationChange::ChangeLoggerConfiguration(config) => self.logger = config,
             SystemConfigurationChange::ChangeChannelConfiguration(idx, config) => {
                 self.channels[idx as usize] = config
+            }
+            SystemConfigurationChange::ChangeMetronomeConfiguration(config) => {
+                self.metronome = config
             }
         }
     }
@@ -38,6 +45,28 @@ impl Default for SystemConfiguration {
                 name: StaticString::empty(),
                 ..ChannelConfiguration::default()
             }; 32],
+            metronome: MetronomeConfiguration {
+                click_primary: MetronomeClick {
+                    frequency: 1200,
+                    length: 4,
+                    wave: MetronomeWaveform::SquircleSine,
+                },
+                click_secondary: MetronomeClick {
+                    frequency: 600,
+                    length: 4,
+                    wave: MetronomeWaveform::SquircleSine,
+                },
+                click_tertiary: MetronomeClick {
+                    frequency: 300,
+                    length: 4,
+                    wave: MetronomeWaveform::SquircleSine,
+                },
+                click_quartenary: MetronomeClick {
+                    frequency: 150,
+                    length: 4,
+                    wave: MetronomeWaveform::SquircleSine,
+                },
+            },
         };
         a.channels[0].name = StaticString::new("Metronome");
         a.channels[1].name = StaticString::new("Timecode");
@@ -58,4 +87,6 @@ pub enum SystemConfigurationChange {
     ChangeLoggerConfiguration(LoggerConfiguration),
     /// Replace the channel configuration at the provided index with the provided configuration
     ChangeChannelConfiguration(u8, ChannelConfiguration),
+    /// Replace the metronome configuration with the provided
+    ChangeMetronomeConfiguration(MetronomeConfiguration),
 }

--- a/local/src/timecodestate.rs
+++ b/local/src/timecodestate.rs
@@ -1,0 +1,11 @@
+use mem::smpte::TimecodeInstant;
+
+/// Status of current SMPTE timecode frame
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Copy, Default)]
+pub struct TimecodeState {
+    /// Is timecode currently running, i.e. is timestamp changing?
+    pub running: bool,
+    /// current LTC timestamp
+    pub ltc: TimecodeInstant,
+}

--- a/local/src/transportstate.rs
+++ b/local/src/transportstate.rs
@@ -1,17 +1,11 @@
-use mem::smpte::TimecodeInstant;
-
 /// Status of current transport location and state
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Copy)]
 pub struct TransportState {
-    /// Time left to next beat in us
-    pub us_to_next_beat: u64,
     /// Is transport currently running, i.e. is location changing
     pub running: bool,
     /// VLT state
     pub vlt: bool,
-    /// current LTC timestamp
-    pub ltc: TimecodeInstant,
     /// Playrate in percent
     pub playrate_percent: u16,
 }
@@ -19,10 +13,8 @@ pub struct TransportState {
 impl Default for TransportState {
     fn default() -> Self {
         Self {
-            us_to_next_beat: 0,
             running: false,
             vlt: false,
-            ltc: TimecodeInstant::default(),
             playrate_percent: 100,
         }
     }

--- a/mem/Cargo.toml
+++ b/mem/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2024"
 bitflags = { version = "2.10.0", features = ["serde"] }
 serde = { version = "1.0.228", features = ["serde_derive", "derive"], default-features = false, optional = true }
 postcard = { version = "1.1.3", optional = true, default-features = false, features = ["alloc"]  }
+serde_json = { version = "1.0.145", optional = true, default-features = false, features = ["alloc"] }
 
 [features]
 serde = ["dep:serde"]
 std = []
 postcard = ["dep:postcard"]
-json = []
+json = ["dep:serde_json"]

--- a/mem/src/message.rs
+++ b/mem/src/message.rs
@@ -7,6 +7,8 @@ bitflags::bitflags! {
         const TransportData = 0x01;
         /// Beat changed
         const BeatData = 0x02;
+        /// Cue changed (lightweight)
+        const SmallCueData = 0x400;
         /// Cue changed
         const CueData = 0x04;
         /// Show changed

--- a/mem/src/message.rs
+++ b/mem/src/message.rs
@@ -5,6 +5,8 @@ bitflags::bitflags! {
     pub struct MessageType: u16 {
         /// Transport changed
         const TransportData = 0x01;
+        /// Transport changed
+        const TimecodeData = 0x800;
         /// Beat changed
         const BeatData = 0x02;
         /// Cue changed (lightweight)
@@ -25,6 +27,8 @@ bitflags::bitflags! {
         const Heartbeat = 0x100;
         /// Event occured
         const EventOccured = 0x200;
+        /// Log occured
+        const Log = 0x1000;
     }
 }
 

--- a/mem/src/str.rs
+++ b/mem/src/str.rs
@@ -285,7 +285,17 @@ impl<const L: usize> serde::Serialize for StaticString<L> {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(self.str())
+        if serializer.is_human_readable() {
+            serializer.serialize_str(self.str())
+        } else {
+            use serde::ser::SerializeTuple;
+
+            let mut seq = serializer.serialize_tuple(L)?;
+            for element in self.content {
+                seq.serialize_element(&element)?;
+            }
+            seq.end()
+        }
     }
 }
 
@@ -301,7 +311,7 @@ impl<'de, const L: usize> serde::Deserialize<'de> for StaticString<L> {
             type Value = StaticString<L>;
 
             fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                write!(f, "a string of exactly {} bytes", L)
+                write!(f, "a u8 string buffer of exactly {} bytes OR a human-readable string {} bytes or shorter", L, L)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -310,9 +320,31 @@ impl<'de, const L: usize> serde::Deserialize<'de> for StaticString<L> {
             {
                 Ok(StaticString::new(v))
             }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut s = StaticString::empty();
+                for index in 0..L {
+                    let next = seq.next_element::<u8>();
+                    match next {
+                        Ok(val) => match val {
+                            None => {}
+                            Some(val) => s.set_char(index, val),
+                        },
+                        Err(err) => return Err(err),
+                    };
+                }
+                Ok(s)
+            }
         }
 
-        deserializer.deserialize_str(StaticStringVisitor::<L>)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(StaticStringVisitor::<L>)
+        } else {
+            deserializer.deserialize_tuple(L, StaticStringVisitor::<L>)
+        }
     }
 }
 
@@ -501,5 +533,28 @@ mod tests {
         assert_eq!(s.str(), "Helli, Wirld!");
         s.replace(b'l', 0);
         assert_eq!(s.str(), "Helli, Wirld!");
+    }
+
+    #[cfg(all(feature = "serde", feature = "postcard"))]
+    #[test]
+    fn serde_binary() {
+        let s = S::<8>::new("abc");
+        let mut buf = [0u8; 16];
+        let serialized = postcard::to_slice(&s, &mut buf).unwrap();
+        assert_eq!(serialized, &[b'a', b'b', b'c', 0, 0, 0, 0, 0]);
+        assert_eq!(serialized.len(), 8);
+        let ss: S<8> = postcard::from_bytes(serialized).unwrap();
+        assert_eq!(ss, s);
+    }
+
+    #[cfg(all(feature = "serde", feature = "json"))]
+    #[test]
+    fn serde_json() {
+        let s = S::<8>::new("abc");
+        let serialized = serde_json::to_string(&s).unwrap();
+        assert_eq!(serialized, "\"abc\"");
+        assert_eq!(serialized.len(), 5);
+        let ss: S<8> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(s, ss);
     }
 }

--- a/mem/src/str.rs
+++ b/mem/src/str.rs
@@ -55,15 +55,9 @@ impl<const L: usize> StaticString<L> {
             return;
         }
 
-        extern crate std;
-
         let mut buf = Self::empty();
-        std::println!("self: {}", self);
-        std::println!("str: {}", str);
         buf.copy_from(*self, idx, L, 0);
-        std::println!("buf: {}", buf);
         self.insert_replace(str, idx);
-        std::println!("self: {}", self);
         if !self.is_full() {
             self.insert_replace(buf, idx + str.len());
         }
@@ -199,7 +193,6 @@ impl<const L: usize> StaticString<L> {
     }
 
     pub fn from_float<T: core::convert::Into<core::primitive::f32>>(value: T) -> Self {
-        extern crate std;
         let mut value: core::primitive::f32 = value.into();
         let neg = value < 0.0;
         let offs = if neg { 1 } else { 0 };

--- a/mem/src/str.rs
+++ b/mem/src/str.rs
@@ -19,6 +19,217 @@ impl<const L: usize> StaticString<L> {
         Self { content: a }
     }
 
+    pub fn from_slice(src: &[u8]) -> Self {
+        let srclen = src.len();
+        let len = if L < srclen { L } else { srclen };
+        let mut a = Self::empty();
+        a.content[..len].copy_from_slice(&src[..len]);
+        a
+    }
+
+    fn copy_from<const N: usize>(
+        &mut self,
+        str: StaticString<N>,
+        start: usize,
+        end: usize,
+        dest: usize,
+    ) {
+        if end > N || start > end || dest >= L || (end - start) + dest > L {
+            return;
+        }
+        self.content[dest..dest + (end - start)].copy_from_slice(&str.content[start..end]);
+    }
+
+    pub fn insert_replace<const N: usize>(&mut self, str: StaticString<N>, idx: usize) {
+        if idx > L {
+            return;
+        }
+        let strlen = str.len();
+        // if idx + strlen > L, i.e. we will run out of destination string when pasting, only take
+        // L - idx, i.e. as many chars as will fit before we run out
+        self.copy_from(str, 0, if idx + strlen > L { L - idx } else { strlen }, idx);
+    }
+
+    pub fn insert_shift<const N: usize>(&mut self, str: StaticString<N>, idx: usize) {
+        if idx > L {
+            return;
+        }
+
+        extern crate std;
+
+        let mut buf = Self::empty();
+        std::println!("self: {}", self);
+        std::println!("str: {}", str);
+        buf.copy_from(*self, idx, L, 0);
+        std::println!("buf: {}", buf);
+        self.insert_replace(str, idx);
+        std::println!("self: {}", self);
+        if !self.is_full() {
+            self.insert_replace(buf, idx + str.len());
+        }
+    }
+
+    pub fn append<const N: usize>(&mut self, str: StaticString<N>) {
+        self.insert_replace(str, self.len());
+    }
+
+    pub fn append_char(&mut self, char: u8) {
+        self.set_char(self.len(), char);
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::empty();
+    }
+
+    pub fn replace(&mut self, from: u8, to: u8) {
+        if from == 0 || to == 0 {
+            return;
+        }
+        for c in &mut self.content {
+            if *c == from {
+                *c = to
+            }
+        }
+    }
+
+    fn len_of_int(mut val: i32) -> i32 {
+        let neg_sign = val < 0;
+        val = val.abs();
+        let mut num_digits = 1;
+        let mut comp = 10;
+        while comp - 1 < val {
+            comp = comp.saturating_mul(10);
+            num_digits += 1;
+        }
+        if neg_sign {
+            num_digits += 1;
+        }
+        num_digits
+    }
+
+    fn len_of_fract(mut val: core::primitive::f32) -> i32 {
+        const EPS: f32 = core::primitive::f32::EPSILON;
+        if val < EPS {
+            return 1;
+        }
+        let mut num_digits = 0;
+        while ((val as u32) as f32 - val).abs() >= EPS {
+            val *= 10.0;
+            num_digits += 1;
+        }
+        num_digits
+    }
+
+    fn write_as_exponent(neg: bool, num: i32, exp: i32) -> Self {
+        if num.abs() > 9 {
+            return Self::empty();
+        }
+        let mut s = Self::empty();
+        if neg {
+            s.append_char(b'-');
+        }
+        s.append_char(0x30 + num as u8);
+        s.append_char(b'e');
+        s.append(Self::from_int(exp));
+        s
+    }
+
+    pub fn from_large_int<T: core::convert::TryInto<i128> + Clone>(value: T) -> Self {
+        let val = if let Ok(val) = value.clone().try_into() {
+            val
+        } else {
+            return Self::empty();
+        };
+
+        // If in range of i32 -> handle as i32
+        if val <= i32::MAX as i128 && val >= i32::MIN as i128 {
+            return Self::from_int(val as i32);
+        };
+
+        // cut down until smaller than i32
+        if let Ok(ival) = value.try_into() {
+            let neg = ival < 0;
+            let mut val: i128 = ival.abs();
+            let mut extra_digits = 0;
+            while val > i32::MAX as i128 {
+                val /= 10;
+                extra_digits += 1;
+            }
+
+            Self::write_as_exponent(
+                neg,
+                Self::top_digit_int(val as i32),
+                Self::len_of_int(val as i32) + extra_digits - 1,
+            )
+        } else {
+            Self::empty()
+        }
+    }
+
+    fn top_digit_int(val: i32) -> i32 {
+        let digits = Self::len_of_int(val.abs());
+        (val.abs() / 10_i32.pow(digits as u32 - 2) + 5) / 10
+    }
+
+    fn units_place_float(val: f32) -> u8 {
+        (val as u32 % 10) as u8
+    }
+
+    pub fn from_int<T: core::convert::Into<i32>>(value: T) -> Self {
+        let mut val: i32 = value.into();
+        let digits = Self::len_of_int(val.abs());
+        let neg = val < 0;
+        let offs = if neg { 1 } else { 0 };
+        let mut s = Self::empty();
+        val = val.abs();
+        if digits as usize + offs > L && L <= 2 + offs {
+            s = Self::new("###");
+        } else if digits as usize + offs > L {
+            s = Self::write_as_exponent(neg, Self::top_digit_int(val), digits - 1);
+        } else {
+            if neg {
+                s.set_char(0, b'-');
+            }
+            for i in (0..digits).rev() {
+                s.set_char(i as usize + offs, 0x30 + (val % 10) as u8);
+                val /= 10;
+            }
+        }
+        s
+    }
+
+    pub fn from_float<T: core::convert::Into<core::primitive::f32>>(value: T) -> Self {
+        extern crate std;
+        let mut value: core::primitive::f32 = value.into();
+        let neg = value < 0.0;
+        let offs = if neg { 1 } else { 0 };
+        let int = value.abs() as i32;
+        let int_digits = Self::len_of_int(int);
+        value = value.abs();
+        let frac = value - (int as f32);
+        let frac_digits = Self::len_of_fract(frac);
+        if offs + int_digits as usize > L {
+            return Self::new("########");
+        }
+
+        let int_s = Self::from_int(int);
+        let mut mul = 10.0;
+        let mut s = Self::empty();
+        if neg {
+            s.append_char(b'-');
+        }
+        s.append(int_s);
+        if offs + int_digits as usize + 1 >= L {
+            return s;
+        }
+        s.append_char(b'.');
+        for _ in 0..frac_digits {
+            s.append_char(0x30 + Self::units_place_float(frac * mul));
+            mul *= 10.0;
+        }
+        s
+    }
+
     pub fn set_char(&mut self, idx: usize, char: u8) {
         if idx < self.content.len() {
             self.content[idx] = char;
@@ -43,6 +254,10 @@ impl<const L: usize> StaticString<L> {
 
     pub fn is_empty(self) -> bool {
         self.len() == 0
+    }
+
+    pub fn is_full(self) -> bool {
+        self.len() == L
     }
 }
 
@@ -104,17 +319,187 @@ impl<'de, const L: usize> serde::Deserialize<'de> for StaticString<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    type S<const L: usize> = StaticString<L>;
 
     #[test]
     fn str_8() {
-        let a = StaticString::<8>::new("");
-        let b = StaticString::<8>::new("abc");
-        let c = StaticString::<8>::new("abcdefgh");
-        let d = StaticString::<8>::new("lmnopqrstuvw");
+        let a = S::<8>::new("");
+        let b = S::<8>::new("abc");
+        let c = S::<8>::new("abcdefgh");
+        let d = S::<8>::new("lmnopqrstuvw");
 
         assert_eq!(a.str(), "");
         assert_eq!(b.str(), "abc");
         assert_eq!(c.str(), "abcdefgh");
         assert_eq!(d.str(), "lmnopqrs");
+    }
+
+    #[test]
+    fn str_from_slice() {
+        let slice_a = [b'H', b'e', b'l', b'l', b'o'];
+        let slice_b = [
+            b'H', b'e', b'l', b'l', b'o', b' ', b'W', b'o', b'r', b'l', b'd', b'!',
+        ];
+        let slice_c = [b'G', b'r', b'e', b'e', b't', b'i', b'n', b'g'];
+        let slice_d = [];
+        let a = S::<8>::from_slice(&slice_a);
+        let b = S::<8>::from_slice(&slice_b);
+        let c = S::<8>::from_slice(&slice_c);
+        let d = S::<8>::from_slice(&slice_d);
+
+        assert_eq!(a.str(), "Hello");
+        assert_eq!(b.str(), "Hello Wo");
+        assert_eq!(c.str(), "Greeting");
+        assert_eq!(d.str(), "");
+    }
+
+    #[test]
+    fn append() {
+        let q = S::<4>::new("xyz");
+        let mut s = S::<4>::empty();
+        let mut ss = S::<8>::new("abcd");
+        s.append(ss);
+        assert_eq!(s.str(), "abcd");
+        ss.append(s);
+        assert_eq!(ss.str(), "abcdabcd");
+        s.clear();
+        ss.clear();
+        s.append(q);
+        assert_eq!(s.str(), "xyz");
+        s.append(q);
+        assert_eq!(s.str(), "xyzx");
+    }
+
+    #[test]
+    fn append_char() {
+        let mut s = S::<4>::empty();
+        s.append_char(b'a');
+        assert_eq!(s.str(), "a");
+        s.append_char(b'b');
+        s.append_char(b'c');
+        s.append_char(b'd');
+        assert_eq!(s.str(), "abcd");
+        s.append_char(b'e');
+        assert_eq!(s.str(), "abcd");
+    }
+
+    #[test]
+    fn len_of_int() {
+        assert_eq!(S::<0>::len_of_int(0), 1);
+        assert_eq!(S::<0>::len_of_int(1), 1);
+        assert_eq!(S::<0>::len_of_int(-1), 2);
+        assert_eq!(S::<0>::len_of_int(-9), 2);
+        assert_eq!(S::<0>::len_of_int(10), 2);
+        assert_eq!(S::<0>::len_of_int(99), 2);
+        assert_eq!(S::<0>::len_of_int(100), 3);
+        assert_eq!(S::<0>::len_of_int(999), 3);
+        assert_eq!(S::<0>::len_of_int(1234), 4);
+        assert_eq!(S::<0>::len_of_int(9999), 4);
+        assert_eq!(S::<0>::len_of_int(-1234), 5);
+    }
+
+    #[test]
+    fn format_ints() {
+        assert_eq!(S::<8>::from_int(0).str(), "0");
+        assert_eq!(S::<8>::from_int(1).str(), "1");
+        assert_eq!(S::<8>::from_int(-1).str(), "-1");
+        assert_eq!(S::<8>::from_int(192).str(), "192");
+        assert_eq!(S::<1>::from_int(1234).str(), "#");
+        assert_eq!(S::<2>::from_int(1234).str(), "##");
+        assert_eq!(S::<3>::from_int(1234).str(), "1e3");
+        assert_eq!(S::<4>::from_int(1234).str(), "1234");
+        assert_eq!(S::<1>::from_int(-1234).str(), "#");
+        assert_eq!(S::<2>::from_int(-1234).str(), "##");
+        assert_eq!(S::<3>::from_int(-1234).str(), "###");
+        assert_eq!(S::<4>::from_int(-1234).str(), "-1e3");
+        assert_eq!(S::<5>::from_int(-1234).str(), "-1234");
+        assert_eq!(S::<8>::from_int(123456789).str(), "1e8");
+        assert_eq!(S::<8>::from_int(187654321).str(), "2e8");
+        assert_eq!(S::<16>::from_int(123456789).str(), "123456789");
+
+        assert_eq!(S::<8>::from_large_int(u32::MAX).str(), "4e9");
+        assert_eq!(S::<8>::from_large_int(1234).str(), "1234");
+        assert_eq!(S::<8>::from_large_int(1e9 as i128).str(), "1e9");
+        assert_eq!(S::<8>::from_large_int(-3e14 as i128).str(), "-3e14");
+        assert_eq!(S::<8>::from_large_int(-1900000000).str(), "-2e9");
+    }
+
+    #[test]
+    fn format_floats() {
+        assert_eq!(S::<8>::from_float(0.0).str(), "0.0");
+        assert_eq!(S::<8>::from_float(0.1).str(), "0.1");
+        assert_eq!(S::<8>::from_float(0.9).str(), "0.9");
+        assert_eq!(S::<8>::from_float(-0.1234).str(), "-0.1234");
+        assert_eq!(S::<8>::from_float(-0.1234567).str(), "-0.12345");
+        assert_eq!(S::<8>::from_float(-0.1234511).str(), "-0.12345");
+        assert_eq!(S::<8>::from_float(0.1234561).str(), "0.123456");
+        assert_eq!(S::<8>::from_float(0.1234569).str(), "0.123456");
+        assert_eq!(S::<3>::from_float(-123.456).str(), "###");
+        assert_eq!(S::<4>::from_float(-123.456).str(), "-123");
+        assert_eq!(S::<5>::from_float(-123.456).str(), "-123");
+        assert_eq!(S::<6>::from_float(-123.456).str(), "-123.4");
+        assert_eq!(S::<7>::from_float(-123.456).str(), "-123.45");
+        assert_eq!(S::<3>::from_float(123.456).str(), "123");
+        assert_eq!(S::<4>::from_float(123.456).str(), "123");
+        assert_eq!(S::<5>::from_float(123.456).str(), "123.4");
+        assert_eq!(S::<6>::from_float(123.456).str(), "123.45");
+        assert_eq!(S::<7>::from_float(123.456).str(), "123.456");
+        assert_eq!(S::<8>::from_float(1.0).str(), "1.0");
+        assert_eq!(S::<8>::from_float(-1.0).str(), "-1.0");
+        assert_eq!(S::<8>::from_float(192.0).str(), "192.0");
+        assert_eq!(S::<1>::from_float(1234.0).str(), "#");
+        assert_eq!(S::<2>::from_float(1234.0).str(), "##");
+        assert_eq!(S::<3>::from_float(1234.0).str(), "###");
+        assert_eq!(S::<4>::from_float(1234.0).str(), "1234");
+        assert_eq!(S::<1>::from_float(-1234.0).str(), "#");
+        assert_eq!(S::<2>::from_float(-1234.0).str(), "##");
+        assert_eq!(S::<3>::from_float(-1234.0).str(), "###");
+        assert_eq!(S::<4>::from_float(-1234.0).str(), "####");
+        assert_eq!(S::<5>::from_float(-1234.0).str(), "-1234");
+    }
+
+    #[test]
+    fn format_exponent() {
+        assert_eq!(S::<8>::write_as_exponent(true, 1, 2).str(), "-1e2");
+        assert_eq!(S::<8>::write_as_exponent(false, 3, 4).str(), "3e4");
+        assert_eq!(S::<8>::write_as_exponent(false, 9, 123).str(), "9e123");
+    }
+
+    #[test]
+    fn top_digit_int() {
+        assert_eq!(S::<0>::top_digit_int(1234), 1);
+        assert_eq!(S::<0>::top_digit_int(2341), 2);
+        assert_eq!(S::<0>::top_digit_int(-3456), 3);
+    }
+
+    #[test]
+    fn insert() {
+        let mut s = S::<8>::new("abcd");
+        let mut ss = S::<8>::new("wxyz");
+        s.insert_replace(ss, 2);
+        assert_eq!(s.str(), "abwxyz");
+        s.insert_shift(ss, 1);
+        assert_eq!(s.str(), "awxyzbwx");
+
+        s = S::new("abwxyz");
+        ss = S::new("wxyz");
+        s.insert_replace(ss, 1);
+        assert_eq!(s.str(), "awxyzz");
+
+        s = S::new("12345678");
+        ss = S::new("abcd");
+        s.insert_replace(ss, 1);
+        assert_eq!(s.str(), "1abcd678");
+    }
+
+    #[test]
+    fn replace() {
+        let mut s = S::<16>::new("Hello, World!");
+        s.replace(b'o', b'i');
+        assert_eq!(s.str(), "Helli, Wirld!");
+        s.replace(0, b'y');
+        assert_eq!(s.str(), "Helli, Wirld!");
+        s.replace(b'l', 0);
+        assert_eq!(s.str(), "Helli, Wirld!");
     }
 }

--- a/mem/src/timecode.rs
+++ b/mem/src/timecode.rs
@@ -83,7 +83,6 @@ impl TimecodeInstant {
 
     /// Add an amount of microseconds to this timestamp.
     pub fn add_us(&mut self, time_us: u64) {
-        extern crate std;
         let us_per_frame = 1_000_000 / self.frame_rate as u64;
         let frames = time_us / us_per_frame;
         let subframe_us = time_us % us_per_frame;

--- a/mem/src/timecode.rs
+++ b/mem/src/timecode.rs
@@ -83,8 +83,16 @@ impl TimecodeInstant {
 
     /// Add an amount of microseconds to this timestamp.
     pub fn add_us(&mut self, time_us: u64) {
-        self.f += (time_us * self.frame_rate as u64 / 1000000) as i8;
-        self.propagate();
+        extern crate std;
+        let us_per_frame = 1_000_000 / self.frame_rate as u64;
+        let frames = time_us / us_per_frame;
+        let subframe_us = time_us % us_per_frame;
+        let progress = subframe_us * 65536 / us_per_frame;
+        self.h += (frames / self.frame_rate as u64 / 60 / 60) as i8;
+        self.m += (frames / self.frame_rate as u64 / 60 % 60) as i8;
+        self.s += (frames / self.frame_rate as u64 % 60) as i8;
+        self.f += (frames % self.frame_rate as u64) as i8;
+        self.add_progress(progress.try_into().unwrap_or_default());
     }
     /// Subtract an amount of microseconds from this timestamp.
     pub fn sub_us(&mut self, time_us: u64) {
@@ -108,6 +116,7 @@ impl TimecodeInstant {
         self.m = m as i8;
         self.s = s as i8;
         self.f = f as i8;
+        self.frame_progress = 0;
     }
 
     // propagate changes to f into the other values
@@ -143,11 +152,34 @@ mod tests {
     #[test]
     fn add_sub_identity() {
         let time_const = TimecodeInstant::new(25);
-        for i in (0..36000 * 1000000).step_by(123456) {
+        for i in (0..36000 * 1000000).step_by(12345678) {
             let mut time = time_const;
             time.add_us(i);
             time.sub_us(i);
             assert_eq!(time, time_const, "Failed with {}us ({} s)", i, i / 1000000);
         }
+    }
+
+    #[test]
+    fn add_us() {
+        const US_PER_FRAME: u64 = 1_000_000 / 25;
+        let mut time = TimecodeInstant::new(25);
+        time.add_us(US_PER_FRAME);
+        assert_eq!(time.f, 1);
+        assert_eq!(time.frame_progress, 0);
+        time.add_us(US_PER_FRAME * 26);
+        assert_eq!(time.f, 2);
+        assert_eq!(time.s, 1);
+        assert_eq!(time.frame_progress, 0);
+        time.add_us(US_PER_FRAME / 2);
+        assert_eq!(time.f, 2);
+        assert_eq!(time.frame_progress, 65535 / 2 + 1);
+
+        time.set_time(0, 0, 0, 0);
+        time.add_us(US_PER_FRAME * 25 * 3605);
+        assert_eq!(time.h, 1);
+        assert_eq!(time.m, 0);
+        assert_eq!(time.s, 5);
+        assert_eq!(time.f, 0);
     }
 }

--- a/protocol/src/message/largemessage.rs
+++ b/protocol/src/message/largemessage.rs
@@ -1,7 +1,7 @@
 use cue::Show;
 #[cfg(feature = "std")]
 use local::{
-    config::SystemConfiguration,
+    config::{LogItem, SystemConfiguration},
     status::{CueState, JACKStatus, NetworkStatus},
 };
 use mem::typeflags::MessageType;
@@ -26,6 +26,8 @@ pub enum LargeMessage {
     /// System configuration has changed. Sent (to all subscribers) as a response to a
     /// ChangeSystemConfiguration request. Also sent on startup
     ConfigurationChanged(SystemConfiguration),
+    /// A log entry was written
+    Log(LogItem),
 }
 
 #[cfg(feature = "std")]
@@ -34,6 +36,7 @@ impl LargeMessage {
     pub fn to_type(&self) -> MessageType {
         match self {
             Self::CueData(..) => MessageType::CueData,
+            Self::Log(..) => MessageType::Log,
             Self::ShowData(..) => MessageType::ShowData,
             Self::NetworkChanged(..) => MessageType::NetworkChanged,
             Self::JACKStateChanged(..) => MessageType::JACKStateChanged,

--- a/protocol/src/message/smallmessage.rs
+++ b/protocol/src/message/smallmessage.rs
@@ -1,6 +1,6 @@
 use crate::message::heartbeat::Heartbeat;
 use event::EventDescription;
-use local::status::{BeatState, TransportState};
+use local::status::{BeatState, SmallCueState, TransportState};
 use mem::typeflags::MessageType;
 
 /// Definition of small messages sent from core to client.
@@ -15,6 +15,8 @@ pub enum SmallMessage {
     TransportData(TransportState),
     /// Current beat has changed. Sent at the start of a new beat during playback
     BeatData(BeatState),
+    /// Current cue has changed. Sent when loading a new cue.
+    CueData(SmallCueState),
     /// A shutdown has been requested. Sent to all subscribers on a Shutdown request, telling them
     /// to unsubscribe and/or disconnect, and expect to not receive subsequent Heartbeats
     ShutdownOccured,
@@ -34,6 +36,7 @@ impl SmallMessage {
             Self::ShutdownOccured => MessageType::ShutdownOccured,
             Self::Heartbeat(..) => MessageType::Heartbeat,
             Self::EventOccured(..) => MessageType::EventOccured,
+            Self::CueData(..) => MessageType::SmallCueData,
         }
     }
 }

--- a/protocol/src/message/smallmessage.rs
+++ b/protocol/src/message/smallmessage.rs
@@ -1,6 +1,6 @@
 use crate::message::heartbeat::Heartbeat;
 use event::EventDescription;
-use local::status::{BeatState, SmallCueState, TransportState};
+use local::status::{BeatState, SmallCueState, TimecodeState, TransportState};
 use mem::typeflags::MessageType;
 
 /// Definition of small messages sent from core to client.
@@ -10,8 +10,8 @@ use mem::typeflags::MessageType;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Copy)]
 pub enum SmallMessage {
-    /// Transport state has changed. Sent once whenever jumping or starting/stopping playback, and
-    /// multiple times per second during playback.
+    /// Transport state has changed. Sent once when jumping, starting/stopping playback and when
+    /// VLT changes
     TransportData(TransportState),
     /// Current beat has changed. Sent at the start of a new beat during playback
     BeatData(BeatState),
@@ -25,6 +25,8 @@ pub enum SmallMessage {
     Heartbeat(Heartbeat),
     /// A playback timeline event just occured
     EventOccured(EventDescription),
+    /// SMPTE Timecode status has changed. Sent once every SMPTE frame
+    TimecodeData(TimecodeState),
 }
 
 impl SmallMessage {
@@ -37,6 +39,7 @@ impl SmallMessage {
             Self::Heartbeat(..) => MessageType::Heartbeat,
             Self::EventOccured(..) => MessageType::EventOccured,
             Self::CueData(..) => MessageType::SmallCueData,
+            Self::TimecodeData(..) => MessageType::TimecodeData,
         }
     }
 }


### PR DESCRIPTION
# Release Notes
- Removed unused custom impl of Debug for `Beat`, in favor of derive.
- Added two new Small Message types: 
  - `CueData(SmallCueState)`, intended for the same use as the Large Message equivalent, but with a tiny uC-friendly payload: `{cue_idx: u16, cue_metadata: CueMetadata}`
  - `TimecodeData(TimecodeState)`, replacing the previous `ltc` value in `TransportData`. 
- Added a new Large Message type: `Log(LogItem)` for communicating log entries directly to client devices.
- Refactored `SmallMessage::TransportState` to remove the `ltc` field. 
  - Changed the documented usage to "_Transport state has changed. Sent once when jumping, starting/stopping playback and when VLT changes_"
- Added new QoL features to StaticString 
- Fixed #17 
- Added `us_to_next_beat` field in BeatState struct

# Compatibility
This update breaks compatibility with 2.0.2 for **network protocol** and **.bin show programming**. Saved .json programming is unchanged.
| Feature | 2.0.2 |
|--------|--------|
| Network | :x: |
| show.bin | :x: |
| show.json | :heavy_check_mark: | 